### PR TITLE
feat: Update Pomolin to v1.1.7

### DIFF
--- a/io.github.redddfoxxyy.pomolin.yml
+++ b/io.github.redddfoxxyy.pomolin.yml
@@ -16,27 +16,25 @@ modules:
     sources:
       - type: git
         url: https://github.com/RedddFoxxyy/Pomolin.git
-        tag: v1.1.6
+        tag: v1.1.7
 
       - type: archive
-        url: https://github.com/RedddFoxxyy/Pomolin/releases/download/v1.1.6/pomolin_x64_linux.tar.gz
-        sha256: "14fb5dfebca437e926bcb42b2ed128b0bff0877ead3ff70f2daeb7c7be822391"
+        url: https://github.com/RedddFoxxyy/Pomolin/releases/download/v1.1.7/pomolin_x64_linux.tar.gz
+        sha256: "8b6de1d809962aa342abaf32695e9c1133f5b528c12805809092f3259e45011c"
         dest: "pomolin"
         only-arches:
           - x86_64
 
       - type: archive
-        url: https://github.com/RedddFoxxyy/Pomolin/releases/download/v1.1.6/pomolin_arm64_linux.tar.gz
-        sha256: "0845dbd0c0650c5f8f22a38faadc0ba53a67a107310a4dcc3d5e680e6a084511"
+        url: https://github.com/RedddFoxxyy/Pomolin/releases/download/v1.1.7/pomolin_arm64_linux.tar.gz
+        sha256: "acf919078d4fd9d855b67764a342f4c4f23f22a60a7a6d3ac5fc418978dc6487"
         dest: "pomolin"
         only-arches:
           - aarch64
 
     build-commands:
-      - cp -r pomolin /app/
+      - cp -r pomolin/* /app/
 
       - install -Dm644 packaging/io.github.redddfoxxyy.pomolin.desktop /app/share/applications/io.github.redddfoxxyy.pomolin.desktop
       - install -Dm644 packaging/io.github.redddfoxxyy.pomolin.svg /app/share/icons/hicolor/scalable/apps/io.github.redddfoxxyy.pomolin.svg
       - install -Dm644 packaging/io.github.redddfoxxyy.pomolin.metainfo.xml /app/share/metainfo/io.github.redddfoxxyy.pomolin.metainfo.xml
-
-      - install -Dm755 packaging/pomolin-launcher.sh /app/bin/pomolin


### PR DESCRIPTION
- Update app version to v1.1.7.
- Simplify manifest build by removing launcher script.
- Update Metainfo Screenshots.